### PR TITLE
修复自定义返回按钮会引发的 bug

### DIFF
--- a/ScrollPageView/ContentView.swift
+++ b/ScrollPageView/ContentView.swift
@@ -36,6 +36,8 @@ public class ContentView: UIView {
     
     /// 所有的子控制器
     private var childVcs: [UIViewController] = []
+    /// 缓存 NavigationController 原来的 PopGestureRecognizerDelegate, 避免自定义返回按钮会引发的 bug
+    private var originalPopGesutreRecognizerDelegate: UIGestureRecognizerDelegate?
     /// 用来判断是否是点击了title, 点击了就不要调用scrollview的代理来进行相关的计算
     private var forbidTouchToAdjustPosition = false
     /// 用来记录开始滚动的offSetX
@@ -105,6 +107,7 @@ public class ContentView: UIView {
         // 设置naviVVc手势代理, 处理pop手势
         if let naviParentViewController = self.parentViewController?.parentViewController as? UINavigationController, let popGesture = naviParentViewController.interactivePopGestureRecognizer {
             
+            self.originalPopGesutreRecognizerDelegate = naviParentViewController.interactivePopGestureRecognizer?.delegate
             naviParentViewController.interactivePopGestureRecognizer?.delegate = self
             // 优先执行naviParentViewController.interactivePopGestureRecognizer的手势
             // 在代理方法中会判断是否真的执行, 不执行的时候就执行scrollView的滚动手势
@@ -120,6 +123,7 @@ public class ContentView: UIView {
     }
     
     deinit {
+        naviParentViewController.interactivePopGestureRecognizer?.delegate = originalPopGesutreRecognizerDelegate
         parentViewController = nil
         print("\(self.debugDescription) --- 销毁")
     }

--- a/ScrollPageView/ContentView.swift
+++ b/ScrollPageView/ContentView.swift
@@ -123,7 +123,9 @@ public class ContentView: UIView {
     }
     
     deinit {
-        naviParentViewController.interactivePopGestureRecognizer?.delegate = originalPopGesutreRecognizerDelegate
+        if let naviParentViewController = self.parentViewController?.parentViewController as? UINavigationController {
+            naviParentViewController.interactivePopGestureRecognizer?.delegate = dddddd
+        }
         parentViewController = nil
         print("\(self.debugDescription) --- 销毁")
     }

--- a/ScrollPageView/ContentView.swift
+++ b/ScrollPageView/ContentView.swift
@@ -124,7 +124,7 @@ public class ContentView: UIView {
     
     deinit {
         if let naviParentViewController = self.parentViewController?.parentViewController as? UINavigationController {
-            naviParentViewController.interactivePopGestureRecognizer?.delegate = dddddd
+            naviParentViewController.interactivePopGestureRecognizer?.delegate = originalPopGesutreRecognizerDelegate
         }
         parentViewController = nil
         print("\(self.debugDescription) --- 销毁")


### PR DESCRIPTION
缓存 NavigationController 原来的 PopGestureRecognizerDelegate, 在被销毁的时候再赋值回去
