### PR TITLE
修复"点击状态栏回到最上"手势失效的问题

### DIFF
--- a/ScrollPageView/ContentView.swift
+++ b/ScrollPageView/ContentView.swift
@@ -41,7 +41,11 @@ public class ContentView: UIView {
     /// 用来记录开始滚动的offSetX
     private var oldOffSetX:CGFloat = 0.0
     private var oldIndex = 0
-    private var currentIndex = 1
+    public private(set) var currentIndex = 1
+    /// 当前显示的子控制器
+    public var currentChildVc: UIViewController {
+        return childVcs[currentIndex]
+    }
     
     // 这里使用weak 避免循环引用
     private weak var parentViewController: UIViewController?
@@ -51,6 +55,7 @@ public class ContentView: UIView {
         let flowLayout = UICollectionViewFlowLayout()
         
         let collection = UICollectionView(frame: CGRectZero, collectionViewLayout: flowLayout)
+        collection.scrollsToTop = false
         
         if let strongSelf = self {
             flowLayout.itemSize = strongSelf.bounds.size

--- a/ScrollPageView/ScrollPageView.swift
+++ b/ScrollPageView/ScrollPageView.swift
@@ -45,6 +45,10 @@ public class ScrollPageView: UIView {
     private var titlesArray: [String] = []
     /// 所有的子控制器
     private var childVcs: [UIViewController] = []
+    /// 当前呈现子控制器
+    public var currentChildVc: UIViewController {
+        return contentView.currentChildVc
+    }
     // 这里使用weak避免循环引用
     private weak var parentViewController: UIViewController?
 

--- a/ScrollPageView/ScrollSegmentView.swift
+++ b/ScrollPageView/ScrollSegmentView.swift
@@ -64,6 +64,7 @@ public class ScrollSegmentView: UIView {
     
     private lazy var scrollView: UIScrollView = {
         let scrollV = UIScrollView()
+        scrollV.scrollsToTop = false
         scrollV.showsHorizontalScrollIndicator = false
         scrollV.bounces = true
         scrollV.pagingEnabled = false


### PR DESCRIPTION
1. 内部所有 ScrollView 及子类的 scrollsToTop 都设置为 false, 避免与 childVC 点击状态栏返回最上的手势冲突
2. 给外部暴露一些关键的接口
